### PR TITLE
chore: upgrade Zig version to 0.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  ZIG_VERSION: 0.15.2
+  ZIG_VERSION: 0.16.0
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Zig
         uses: mlugg/setup-zig@v2.0.5
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Formatting
         run: zig fmt --check --color on .

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
 
     .fingerprint = 0x499ae5d2db8fed70,
 
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
 
     .dependencies = .{
         .secp256k1 = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,8 +21,8 @@
             .hash = "multiaddr-0.1.0-Cjayds-5AAArNw0ghMgquaRygVf7-kEWQJlQGjVpZzZ0",
         },
         .peer_id = .{
-            .url = "git+https://github.com/blockblaz/peer-id#41f336b92315dcbc852345a2468487c697cfdcbe",
-            .hash = "peer_id-0.0.0-vHIk8ZdfAADctTzIgznksWwEzygVynEeSKDim42Pz-QL",
+            .url = "git+https://github.com/blockblaz/peer-id#a6fbdb8241c38ac57e420fa95c32f364a954cced",
+            .hash = "peer_id-0.0.0-vHIk8YxeAAD4KyWTd0fQo_ml_REyx8MQy72OD5OOIqn-",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
 
     .dependencies = .{
         .secp256k1 = .{
-            .url = "git+https://github.com/blockblaz/libsecp256k1-zig#518a1370b66c6b575b4831c4a1a182f5b30b3d75",
-            .hash = "secp256k1-0.0.3-vtxi58DhAABoPpDgG3wagaDXiHHIDezLOPE0BI4V0bDS",
+            .url = "git+https://github.com/blockblaz/libsecp256k1-zig#c4c108996e0598d3267620c32cf6c7e197bd4e53",
+            .hash = "secp256k1-0.0.3-vtxi577hAAD8sNCl5L9rrPhONGE7qSBvgnr6rzH--Ep5",
         },
         .zmultiformats = .{
             .url = "git+https://github.com/zen-eth/multiformats-zig#ddf4f0af34ce8f87c2dc7df73a261738c3868093",


### PR DESCRIPTION
Bumps minimum_zig_version and CI zig version from 0.15.2 to 0.16.0.

Changes:
- build.zig.zon: minimum_zig_version 0.15.2 to 0.16.0
- .github/workflows/ci.yml: ZIG_VERSION env var and setup-zig version both updated to 0.16.0

CI will confirm build and test compatibility.